### PR TITLE
Add support for named colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
 			"version": "2.1.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
+				"colornames": "^1.1.1",
 				"json5": "^2.2.1"
 			},
 			"devDependencies": {
+				"@types/colornames": "^1.1.2",
 				"@types/json5": "^2.2.0",
 				"@types/node": "14.x",
 				"@types/vscode": "^1.65.0",
@@ -121,6 +123,12 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/@types/colornames": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/colornames/-/colornames-1.1.2.tgz",
+			"integrity": "sha512-tq8AZME3IzZDtW/xpgk6EjqMCtIy5c8/YthsRDSkfj10O8y7QNpD5A22GQf5ziB4OaX7u1jtWu5werbjAKFleQ==",
+			"dev": true
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.4.1",
@@ -1052,6 +1060,11 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
+		},
+		"node_modules/colornames": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+			"integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
@@ -4183,6 +4196,12 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
+		"@types/colornames": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/colornames/-/colornames-1.1.2.tgz",
+			"integrity": "sha512-tq8AZME3IzZDtW/xpgk6EjqMCtIy5c8/YthsRDSkfj10O8y7QNpD5A22GQf5ziB4OaX7u1jtWu5werbjAKFleQ==",
+			"dev": true
+		},
 		"@types/eslint": {
 			"version": "8.4.1",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -4881,6 +4900,11 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
+		},
+		"colornames": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+			"integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
 		},
 		"commander": {
 			"version": "2.20.3",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
 		"deploy": "node ./publish.js"
 	},
 	"devDependencies": {
+		"@types/colornames": "^1.1.2",
 		"@types/json5": "^2.2.0",
 		"@types/node": "14.x",
 		"@types/vscode": "^1.65.0",
@@ -208,6 +209,7 @@
 		"webpack-cli": "^4.9.2"
 	},
 	"dependencies": {
+		"colornames": "^1.1.1",
 		"json5": "^2.2.1"
 	}
 }

--- a/src/decorationRangeHandler.ts
+++ b/src/decorationRangeHandler.ts
@@ -3,6 +3,7 @@ import { hexToHsl, hslToHex, decimalToHexString } from './helpers/colorHelpers';
 import { colorBlockRegex } from './helpers/colorBlockRegex';
 import { arrAdd, getIndention } from './helpers/miscHelpers';
 import { Comment } from './commentConfigHandler';
+import toHex = require('colornames');
 
 interface ContentRange {
     content: any;
@@ -112,6 +113,13 @@ export class DecorationRangeHandler {
             if (!match)
                 continue;
 
+            const colorHex = match.groups?.color.startsWith('#')
+                ? match.groups.color
+                : toHex(match.groups?.color ?? ''); // returns undefined if argument isn't a named color
+
+            if (!colorHex)
+                continue;
+
             const commentStartLineNumber = doc.positionAt(comment.range[0]).line;
             const commentEndLineNumber = doc.positionAt(comment.range[1]).line;
 
@@ -150,7 +158,7 @@ export class DecorationRangeHandler {
                     range: arrAdd(match.indices![0]!, matchOffset) as [number, number]
                 },
                 hexColor: {
-                    content: match.groups!.color,
+                    content: colorHex,
                     range: arrAdd(match.indices!.groups!.color, matchOffset) as [number, number]
                 },
                 nLines: nLines,

--- a/src/helpers/colorBlockRegex.ts
+++ b/src/helpers/colorBlockRegex.ts
@@ -15,7 +15,10 @@ const regexString = mulitlineRegex`
 \s*
     (?:                                     // Mandatory argument:
         (?:color\s*:\s*)?                   //  Optional key word
-        (?<color>#(?:[0-9a-f]{3}){1,2})     //  Capture mandatory 3-6 letter hexcolor -> group name "color"
+        (?<color>(?:                        //  Capture mandatory color specifier -> group name "color"
+            (#(?:[0-9a-f]{3}){1,2})         //   3-6 letter hexcolor
+            |(\w+)                          //   ... OR named color (arbitrary word)
+        ))
     )
 \s*
     (?:                                     // Optional argument:

--- a/test/regex_test.txt
+++ b/test/regex_test.txt
@@ -10,6 +10,10 @@ VALID:
 { color : #123 , lines : 2 }
 { color : #123 }
 {#abc}
+{orangered}
+{orangered,2}
+{color:orangered}
+{color:orangered,2}
 
 INVALID
 {#abg,2}
@@ -21,3 +25,7 @@ INVALID
 {color:"#123",lines:"2"}
 { lines : 2 }
 {,lines:2}
+{#orangered}
+{#orangered,2}
+{color:#orangered}
+{color:#orangered,2}


### PR DESCRIPTION
Hello! I've been enjoying this extension, particularly for making annotations while reading code. But the inability to quickly pick nice colors from memory was getting to me, so here we are!

This change adds the ability to specify colors by name, using the [html color keywords](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color_keywords).

Specifically it's using the [`colornames`](https://github.com/timoxley/colornames) package. A full list of supported names is in the docs, but note that any of the numbered variants won't be captured by the regex at the moment.

I'd considered adding a map of specific names to hex values as a key in settings (with the standard html names maybe acting as the default), but that seemed like overkill for now. l'm using this change locally, and it's scratched my itch.

Thanks for all the work you've put into this! 🙏