### PR TITLE
feat(settings): add configurable debounce interval and leading-edge update

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,16 @@
 						"default": true,
 						"description": "Toggle showing color blocks.",
 						"scope": "window"
-					}
+					},
+					"color-blocks.behavior.debounceInterval": {
+						"type": "number",
+						"default": 100,
+                        "multipleOf": 1,
+                        "minimum": 20,
+                        "maximum": 10000,
+						"description": "Minimum delay in milliseconds between consecutive color block updates to reduce performance overhead. (min: 20ms, max: 10s)",
+						"scope": "window"
+					}                    
 				}
 			}
 		]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,14 +28,18 @@ const editorChange = (editor: vscode.TextEditor | undefined) => {
 /* 
 * IMPORTANT:
 * To avoid calling update too often,
-* set a timer for 100ms to wait before drawing
+* this function implements a "leading-edge debounce"
+* with a configurable delay via the settings.
 Copied from: https://github.com/aaron-bond/better-comments/blob/master/src/extension.ts
-{#88f,14}
+{#88f,18}
 */
-let timeout: NodeJS.Timer;
+let timeout: NodeJS.Timer | undefined;
 const triggerUpdateDecorations = () => {
+    let delay: number = 20; // ms
+    
     if (timeout) {
         clearTimeout(timeout);
+        delay = settings.behavior.debounceInterval; // ms
     }
     timeout = setTimeout(async () => {
         decorationRangeHandler.decorationRanges = [];
@@ -44,7 +48,8 @@ const triggerUpdateDecorations = () => {
             decorationRangeHandler.addNewDecorationRanges(activeEditor, comments);
         }
         decorationRangeHandler.redrawDecorationRanges(activeEditor, settings); // This one takes a long time
-    }, 100);
+        timeout = undefined;
+    }, delay );
 };
 
 


### PR DESCRIPTION
- Introduced setting `color-blocks.behavior.debounceInterval` (ms) to control update delay.
- Replaced hard-coded 100ms timer with the configurable value.
- Changed update logic to a leading-edge debounce: first update runs instantly, subsequent updates are delayed to reduce freezes on large files.

This change is related to the feature request https://github.com/zimonitrome/vscode-color-blocks/issues/14 and can probably help with the https://github.com/zimonitrome/vscode-color-blocks/issues/17