### PR TITLE
Add left padding to wrapped color blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
 						"default": 1,
 						"description": "Padding to add to the right of the color block if `wrapText` is enabled. Measured in characters.",
 						"scope": "window"
+					},
+					"color-blocks.wrapText.paddingLeft": {
+						"type": "number",
+						"default": 1,
+						"description": "Padding to add between the left border and code if `wrapText` is enabled. Measured in characters.",
+						"scope": "window"
 					}
 				}
 			},

--- a/src/decorationRangeHandler.ts
+++ b/src/decorationRangeHandler.ts
@@ -290,8 +290,9 @@ export class DecorationRangeHandler {
             if (shortestIndentation === Infinity)
                 shortestIndentation = 0;
 
-            left = `${shortestIndentation}ch`;
-            customWidth = `${Math.max(0, longestLineWidth - shortestIndentation) + settings.wrapText.paddingRight}ch`;
+            const paddingLeft = settings.wrapText.paddingLeft ?? 1;
+            left = `${Math.max(0, shortestIndentation - paddingLeft)}ch`;
+            customWidth = `${Math.max(0, longestLineWidth - shortestIndentation) + paddingLeft + settings.wrapText.paddingRight}ch`;
         }
         else {
             // Otherwise, stretch to the entire width of the editor minus the scrollbar
@@ -386,6 +387,7 @@ export class DecorationRangeHandler {
                     key,
                     left,
                     customWidth,
+                    settings.wrapText.paddingLeft ?? 1,
                 ].join('|'),
                 lineDecorationOptions,
                 ranges


### PR DESCRIPTION
Closes #27.\n\n## Summary\n- add a configurable `color-blocks.wrapText.paddingLeft` setting\n- expand wrapped color blocks to the left by the configured padding so code is not flush with the left border\n- include the left padding value in the decoration cache key\n\n## Validation\n- `./node_modules/.bin/eslint src --ext ts`\n- `npm run compile` currently fails on an existing TypeScript compatibility issue: `ColorThemeKind.HighContrastLight` is not available in the repository's configured `@types/vscode@^1.63.0`